### PR TITLE
refactor: abolish custom context keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,22 +196,22 @@
         },
         {
           "command": "sortable-explorer.toggleSortDirection.desc",
-          "when": "view == sortable-explorer.fileExplorer && (sortable-explorer.sortDirectionIcon == 'desc' || !sortable-explorer.sortDirectionIcon)",
+          "when": "view == sortable-explorer.fileExplorer && config.sortable-explorer.sortDirection == 'desc'",
           "group": "navigation@200"
         },
         {
           "command": "sortable-explorer.toggleSortDirection.asc",
-          "when": "view == sortable-explorer.fileExplorer && sortable-explorer.sortDirectionIcon == 'asc'",
+          "when": "view == sortable-explorer.fileExplorer && config.sortable-explorer.sortDirection == 'asc'",
           "group": "navigation@200"
         },
         {
           "command": "sortable-explorer.toggleViewMode.tree",
-          "when": "view == sortable-explorer.fileExplorer && (sortable-explorer.viewModeIcon == 'tree' || !sortable-explorer.viewModeIcon)",
+          "when": "view == sortable-explorer.fileExplorer && config.sortable-explorer.viewMode == 'tree'",
           "group": "navigation@300"
         },
         {
           "command": "sortable-explorer.toggleViewMode.flat",
-          "when": "view == sortable-explorer.fileExplorer && sortable-explorer.viewModeIcon == 'flat'",
+          "when": "view == sortable-explorer.fileExplorer && config.sortable-explorer.viewMode == 'flat'",
           "group": "navigation@300"
         },
         {

--- a/src/commands/toggleSortDirectionCommand.ts
+++ b/src/commands/toggleSortDirectionCommand.ts
@@ -41,22 +41,5 @@ export function toggleSortDirectionCommand(
     vscode.window.showInformationMessage(
       localize("sortDirection.changed", directionName)
     );
-
-    // アイコンを更新
-    updateSortDirectionIcon(newSortDirection);
   };
-}
-
-/**
- * 並び順の方向に応じてアイコンを更新する
- *
- * @param sortDirection 並び順の方向
- */
-export function updateSortDirectionIcon(sortDirection: SortDirectionType) {
-  // コマンドのアイコンを更新
-  vscode.commands.executeCommand(
-    "setContext",
-    CONTEXT_KEYS.SORT_DIRECTION_ICON,
-    sortDirection
-  );
 }

--- a/src/commands/toggleViewModeCommand.ts
+++ b/src/commands/toggleViewModeCommand.ts
@@ -39,22 +39,5 @@ export function toggleViewModeCommand(
     vscode.window.showInformationMessage(
       localize("viewMode.changed", modeName)
     );
-
-    // アイコンを更新
-    updateViewModeIcon(newViewMode);
   };
-}
-
-/**
- * 表示モードに応じてアイコンを更新する
- *
- * @param viewMode 表示モード
- */
-export function updateViewModeIcon(viewMode: ViewModeType) {
-  // コマンドのアイコンを更新
-  vscode.commands.executeCommand(
-    "setContext",
-    CONTEXT_KEYS.VIEW_MODE_ICON,
-    viewMode
-  );
 }

--- a/src/configuration/configurationConstants.ts
+++ b/src/configuration/configurationConstants.ts
@@ -63,7 +63,4 @@ export const DefaultPatterns = {
 } as const;
 
 // コンテキストキー
-export const CONTEXT_KEYS = {
-  SORT_DIRECTION_ICON: `${EXTENSION_NAME}.sortDirectionIcon`,
-  VIEW_MODE_ICON: `${EXTENSION_NAME}.viewModeIcon`,
-} as const;
+export const CONTEXT_KEYS = {} as const;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,14 +16,8 @@ import { openSettingsCommand } from "./commands/openSettingsCommand";
 import { refreshFileExplorerCommand } from "./commands/refreshFileExplorerCommand";
 import { renameFileCommand } from "./commands/renameFileCommand";
 import { selectSortByCommand } from "./commands/selectSortByCommand";
-import {
-  toggleSortDirectionCommand,
-  updateSortDirectionIcon,
-} from "./commands/toggleSortDirectionCommand";
-import {
-  toggleViewModeCommand,
-  updateViewModeIcon,
-} from "./commands/toggleViewModeCommand";
+import { toggleSortDirectionCommand } from "./commands/toggleSortDirectionCommand";
+import { toggleViewModeCommand } from "./commands/toggleViewModeCommand";
 import {
   COMMANDS,
   EXTENSION_NAME,
@@ -53,14 +47,6 @@ export function activate(context: vscode.ExtensionContext) {
 
   // BookmarkExplorerProviderのインスタンスを作成 (BookmarkManagerを渡す)
   const bookmarkExplorerProvider = new BookmarkExplorerProvider(bookmarkManager);
-
-  // 初期状態の並び順の方向に応じてアイコンを設定
-  const initialSortDirection = ConfigurationManager.getSortDirection();
-  updateSortDirectionIcon(initialSortDirection);
-
-  // 初期状態の表示モードに応じてアイコンを設定
-  const initialViewMode = ConfigurationManager.getViewMode();
-  updateViewModeIcon(initialViewMode);
 
   // 既存のファイルエクスプローラービューの登録
   vscode.window.registerTreeDataProvider(


### PR DESCRIPTION
<!-- PR作成時は以下のテンプレートに従って記入してください -->

## 変更内容
VSCodeのカスタムコンテキストキー (`sortableExplorer.viewMode`, `sortableExplorer.sortDirection`) の使用を廃止し、代わりにVSCodeの組み込みコンテキストキー (`config.sortableExplorer.viewMode`, `config.sortableExplorer.sortDirection`) を使用するようにリファクタリングしました。これにより、`when`句の記述が簡潔になり、VSCodeの標準的な方法に準拠します。

## 関連するIssue
<!-- 関連するIssueがある場合は、「#123」のように記述してください -->
Closes #

## 変更の種類
<!-- 該当する項目に x を入れてください（例: [x] ） -->
- [ ] バグ修正（既存機能の修正）
- [ ] 新機能（既存機能に影響しない変更）
- [ ] 破壊的変更（既存機能に影響する変更）
- [ ] ドキュメントのみの変更
- [x] リファクタリング（機能変更なし）
- [ ] パフォーマンス改善
- [ ] テストの追加・修正
- [ ] ビルドプロセスや補助ツールの変更
- [ ] その他（詳細を記述）

## チェックリスト
<!-- 該当する項目に x を入れてください（例: [x] ） -->
- [x] コードスタイルに準拠している
- [x] 自己レビューを行った
- [ ] コメントを追加・更新した（特に複雑な部分）
- [ ] ドキュメントを更新した（必要な場合）
- [ ] テストを追加・更新した（必要な場合）
- [x] 変更がローカルでテスト済み

## スクリーンショット（必要な場合）
<!-- UI変更がある場合は、変更前後のスクリーンショットを添付してください -->

## その他の情報
<!-- レビュアーに伝えたい追加情報があれば記述してください -->