### PR TITLE
feat: show file description only in flat view mode

### DIFF
--- a/src/fileExplorer/fileItem.ts
+++ b/src/fileExplorer/fileItem.ts
@@ -1,7 +1,7 @@
-import * as vscode from "vscode";
 import * as path from "path";
-import * as fs from "fs";
+import * as vscode from "vscode";
 import { BookmarkManager } from "../bookmark/BookmarkManager"; // BookmarkManagerをインポート
+import { ViewMode, ViewModeType } from "../configuration/configurationConstants"; // ViewModeとViewModeTypeをインポート
 
 export class FileItem extends vscode.TreeItem {
   public isBookmarked: boolean = false; // ブックマーク状態を保持
@@ -14,7 +14,8 @@ export class FileItem extends vscode.TreeItem {
     public readonly resourceUri: vscode.Uri,
     public readonly isDirectory: boolean = false,
     public readonly parent?: FileItem,
-    bookmarkManager?: BookmarkManager // BookmarkManagerを受け取る (オプション)
+    bookmarkManager?: BookmarkManager, // BookmarkManagerを受け取る (オプション)
+    viewMode?: ViewModeType // ViewModeTypeに変更
   ) {
     super(
       resourceUri,
@@ -36,8 +37,13 @@ export class FileItem extends vscode.TreeItem {
       this.contextValue = "fileItem"; // ブックマークされていない場合
     }
 
-    if (!isDirectory) {
+    // descriptionはFlatモードのファイルのみに設定
+    if (!isDirectory && viewMode === ViewMode.FLAT) {
       this.description = this.getRelativeFolderPath();
+    }
+
+    // commandはファイルの場合に設定 (ViewModeによらず)
+    if (!isDirectory) {
       this.command = {
         command: "vscode.open",
         title: "Open File",

--- a/src/fileExplorer/fileSystemHelper.ts
+++ b/src/fileExplorer/fileSystemHelper.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { FileItem } from "./fileItem";
 import { ConfigurationManager } from "../configuration/configurationManager";
-import { ViewMode } from "../configuration/configurationConstants";
+import { ViewMode, ViewModeType } from "../configuration/configurationConstants";
 import { FileSystemStrategy } from "./strategies/fileSystemStrategy";
 import { FlatFileSystemStrategy } from "./strategies/flatFileSystemStrategy";
 import { TreeFileSystemStrategy } from "./strategies/treeFileSystemStrategy";
@@ -9,54 +9,62 @@ import { BookmarkManager } from "../bookmark/BookmarkManager"; // BookmarkManage
 
 export class FileSystemHelper {
   private strategies: Map<string, FileSystemStrategy>;
-  private currentStrategy: FileSystemStrategy;
+  private currentStrategy: FileSystemStrategy; // createNewNote など、viewModeに依存しない操作で使用
 
   constructor() {
     // 利用可能な戦略を登録
     this.strategies = new Map<string, FileSystemStrategy>();
     this.strategies.set(ViewMode.FLAT, new FlatFileSystemStrategy());
     this.strategies.set(ViewMode.TREE, new TreeFileSystemStrategy());
-    
-    // デフォルト戦略を設定
-    const viewMode = ConfigurationManager.getViewMode();
-    this.currentStrategy = this.strategies.get(viewMode) || this.strategies.get(ViewMode.FLAT)!;
+
+    // デフォルト戦略を設定 (主にcreateNewNote用)
+    const initialViewMode = ConfigurationManager.getViewMode();
+    this.currentStrategy = this.strategies.get(initialViewMode) || this.strategies.get(ViewMode.FLAT)!;
   }
 
   /**
    * 指定されたディレクトリ内のすべてのファイルを取得
-   * 現在の表示モードに応じた戦略を使用
+   * 指定された表示モードに応じた戦略を使用
    *
    * @param workspacePath 検索するディレクトリのパス
    * @param includes 表示するファイル/フォルダのパターン配列
    * @param excludes 表示から除外するファイル/フォルダのパターン配列
+   * @param viewMode 表示モード
+   * @param bookmarkManager ブックマークマネージャー
    * @returns FileItemオブジェクトの配列
    */
   public async getFiles(
     workspacePath: string,
     includes: string[],
     excludes: string[],
+    viewMode: ViewModeType, // ViewModeを追加
     bookmarkManager?: BookmarkManager // BookmarkManagerをオプションで受け取る
   ): Promise<FileItem[]> {
-    // 表示モードを取得して適切な戦略を設定
-    const viewMode = ConfigurationManager.getViewMode();
-    this.currentStrategy = this.strategies.get(viewMode) || this.currentStrategy;
+    // パラメータで渡されたviewModeに基づいて戦略を選択
+    const strategy = this.strategies.get(viewMode) || this.strategies.get(ViewMode.FLAT)!;
 
-    // 選択された戦略を使用してファイルを取得 (BookmarkManagerを渡す)
-    return this.currentStrategy.getFiles(workspacePath, includes, excludes, bookmarkManager);
+    // 選択された戦略を使用してファイルを取得 (BookmarkManagerとViewModeを渡す)
+    return strategy.getFiles(workspacePath, includes, excludes, viewMode, bookmarkManager);
   }
 
   /**
    * 指定されたディレクトリの子要素を取得
+   * 指定された表示モードに応じた戦略を使用
    */
   public async getChildren(
     directoryPath: string,
     includes: string[],
     excludes: string[],
+    viewMode: ViewModeType, // ViewModeTypeに変更
     bookmarkManager?: BookmarkManager // BookmarkManagerをオプションで受け取る
   ): Promise<FileItem[]> {
-    // 選択された戦略を使用して子要素を取得 (BookmarkManagerを渡す)
+    // パラメータで渡されたviewModeに基づいて戦略を選択
+    // Treeモード以外は空配列を返す想定だが念のため
+    const strategy = this.strategies.get(viewMode) || this.strategies.get(ViewMode.TREE)!; // getChildrenはTree戦略が主
+
+    // 選択された戦略を使用して子要素を取得 (BookmarkManagerとViewModeを渡す)
     // Tree戦略のみがgetChildrenを実装している想定だが、念のため渡す
-    return this.currentStrategy.getChildren(directoryPath, includes, excludes, bookmarkManager);
+    return strategy.getChildren(directoryPath, includes, excludes, viewMode, bookmarkManager);
   }
 
   /**
@@ -67,16 +75,17 @@ export class FileSystemHelper {
    * @returns 作成されたファイルのパス
    */
   public async createNewNote(targetDirectory: string, title: string): Promise<string> {
+    // createNewNoteはViewModeに依存しないため、コンストラクタで設定したcurrentStrategyを使用
     return this.currentStrategy.createNewNote(targetDirectory, title);
   }
-  
+
   /**
    * 戦略を直接設定するメソッド（テストなどで使用）
    */
   public setStrategy(strategy: FileSystemStrategy): void {
     this.currentStrategy = strategy;
   }
-  
+
   /**
    * 新しい戦略を登録するメソッド（拡張性のため）
    */

--- a/src/fileExplorer/strategies/fileSystemStrategy.ts
+++ b/src/fileExplorer/strategies/fileSystemStrategy.ts
@@ -1,5 +1,6 @@
 import { FileItem } from "../fileItem";
 import { BookmarkManager } from "../../bookmark/BookmarkManager"; // BookmarkManagerをインポート
+import { ViewModeType } from "../../configuration/configurationConstants"; // ViewModeTypeをインポート
 
 export interface FileSystemStrategy {
   /**
@@ -9,6 +10,7 @@ export interface FileSystemStrategy {
     workspacePath: string,
     includes: string[],
     excludes: string[],
+    viewMode: ViewModeType, // ViewModeTypeに変更
     bookmarkManager?: BookmarkManager // BookmarkManagerをオプション引数として追加
   ): Promise<FileItem[]>;
 
@@ -19,19 +21,20 @@ export interface FileSystemStrategy {
     directoryPath: string,
     includes: string[],
     excludes: string[],
+    viewMode: ViewModeType, // ViewModeTypeに変更
     bookmarkManager?: BookmarkManager // BookmarkManagerをオプション引数として追加
   ): Promise<FileItem[]>;
-  
+
   /**
    * 新しいノートファイルを作成する
    */
   createNewNote(targetDirectory: string, title: string): Promise<string>;
-  
+
   /**
    * 指定されたパスが除外パターンに一致するかチェック
    */
   isExcluded(filePath: string, excludes: string[], basePath: string): boolean;
-  
+
   /**
    * 指定されたパスがincludeパターンに一致するかチェック
    */

--- a/src/fileExplorer/strategies/fileSystemStrategyBase.ts
+++ b/src/fileExplorer/strategies/fileSystemStrategyBase.ts
@@ -5,6 +5,8 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { FileItem } from "../fileItem";
 import { FileSystemStrategy } from "./fileSystemStrategy";
+import { ViewMode, ViewModeType } from "../../configuration/configurationConstants"; // ViewModeとViewModeTypeをインポート
+import { BookmarkManager } from "../../bookmark/BookmarkManager"; // BookmarkManagerをインポート
 
 export abstract class FileSystemStrategyBase implements FileSystemStrategy {
   /**
@@ -14,7 +16,9 @@ export abstract class FileSystemStrategyBase implements FileSystemStrategy {
   abstract getFiles(
     workspacePath: string,
     includes: string[],
-    excludes: string[]
+    excludes: string[],
+    viewMode: ViewModeType, // ViewModeTypeに変更
+    bookmarkManager?: BookmarkManager // BookmarkManagerを追加
   ): Promise<FileItem[]>;
 
   /**
@@ -23,7 +27,9 @@ export abstract class FileSystemStrategyBase implements FileSystemStrategy {
   public async getChildren(
     directoryPath: string,
     includes: string[],
-    excludes: string[]
+    excludes: string[],
+    viewMode: ViewModeType, // ViewModeTypeに変更
+    bookmarkManager?: BookmarkManager // BookmarkManagerを追加
   ): Promise<FileItem[]> {
     try {
       const result: FileItem[] = [];
@@ -54,7 +60,10 @@ export abstract class FileSystemStrategyBase implements FileSystemStrategy {
               stats.mtime,
               stats.birthtime,
               vscode.Uri.file(dirPath),
-              true // isDirectory = true
+              true, // isDirectory = true
+              undefined, // parent は undefined
+              bookmarkManager, // BookmarkManagerを渡す
+              viewMode // viewModeを渡す
             )
           );
         } catch (error) {
@@ -91,7 +100,10 @@ export abstract class FileSystemStrategyBase implements FileSystemStrategy {
               stats.mtime,
               stats.birthtime,
               vscode.Uri.file(filePath),
-              false // isDirectory = false
+              false, // isDirectory = false
+              undefined, // parent は undefined
+              bookmarkManager, // BookmarkManagerを渡す
+              viewMode // viewModeを渡す
             )
           );
         } catch (error) {
@@ -125,7 +137,7 @@ export abstract class FileSystemStrategyBase implements FileSystemStrategy {
     const baseFileName = `${dateStr}_${title}`;
     let fileName = `${baseFileName}.md`;
     let filePath = path.join(targetDirectory, fileName);
-    
+
     // ファイルが存在するかチェックし、存在する場合は連番を付ける
     let counter = 1;
     while (true) {

--- a/src/fileExplorer/strategies/flatFileSystemStrategy.ts
+++ b/src/fileExplorer/strategies/flatFileSystemStrategy.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import { FileItem } from "../fileItem";
 import { FileSystemStrategyBase } from "./fileSystemStrategyBase";
 import { BookmarkManager } from "../../bookmark/BookmarkManager"; // BookmarkManagerをインポート
+import { ViewMode, ViewModeType } from "../../configuration/configurationConstants"; // ViewModeとViewModeTypeをインポート
 
 export class FlatFileSystemStrategy extends FileSystemStrategyBase {
   /**
@@ -15,6 +16,7 @@ export class FlatFileSystemStrategy extends FileSystemStrategyBase {
     workspacePath: string,
     includes: string[],
     excludes: string[],
+    viewMode: ViewModeType, // ViewModeTypeに変更
     bookmarkManager?: BookmarkManager // BookmarkManagerをオプション引数として追加
   ): Promise<FileItem[]> {
     // fast-globのパターンを準備: からの場合はすべてを対象とする
@@ -51,7 +53,8 @@ export class FlatFileSystemStrategy extends FileSystemStrategyBase {
           vscode.Uri.file(filePath),
           false, // isDirectory は false
           undefined, // parent は undefined
-          bookmarkManager // BookmarkManagerを渡す
+          bookmarkManager, // BookmarkManagerを渡す
+          viewMode // ViewModeを渡す
         )
       );
     }

--- a/src/fileExplorer/strategies/treeFileSystemStrategy.ts
+++ b/src/fileExplorer/strategies/treeFileSystemStrategy.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import { FileItem } from "../fileItem";
 import { FileSystemStrategyBase } from "./fileSystemStrategyBase";
 import { BookmarkManager } from "../../bookmark/BookmarkManager"; // BookmarkManagerをインポート
+import { ViewMode, ViewModeType } from "../../configuration/configurationConstants"; // ViewModeとViewModeTypeをインポート
 
 export class TreeFileSystemStrategy extends FileSystemStrategyBase {
   /**
@@ -15,9 +16,11 @@ export class TreeFileSystemStrategy extends FileSystemStrategyBase {
     workspacePath: string,
     includes: string[],
     excludes: string[],
+    viewMode: ViewModeType, // ViewModeTypeに変更
     bookmarkManager?: BookmarkManager // BookmarkManagerをオプション引数として追加
   ): Promise<FileItem[]> {
-    return this.readDirectory(workspacePath, includes, excludes, bookmarkManager);
+    // readDirectoryにviewModeを渡す
+    return this.readDirectory(workspacePath, includes, excludes, viewMode, bookmarkManager);
   }
 
   /**
@@ -27,10 +30,12 @@ export class TreeFileSystemStrategy extends FileSystemStrategyBase {
     directoryPath: string,
     includes: string[],
     excludes: string[],
+    viewMode: ViewModeType, // ViewModeTypeに変更
     bookmarkManager?: BookmarkManager // BookmarkManagerをオプション引数として追加
   ): Promise<FileItem[]> {
     // getFilesと同じロジックでディレクトリを読む
-    return this.readDirectory(directoryPath, includes, excludes, bookmarkManager);
+    // readDirectoryにviewModeを渡す
+    return this.readDirectory(directoryPath, includes, excludes, viewMode, bookmarkManager);
   }
 
   /**
@@ -40,6 +45,7 @@ export class TreeFileSystemStrategy extends FileSystemStrategyBase {
     directoryPath: string,
     includes: string[],
     excludes: string[],
+    viewMode: ViewModeType, // ViewModeTypeに変更
     bookmarkManager?: BookmarkManager
   ): Promise<FileItem[]> {
     try {
@@ -70,7 +76,8 @@ export class TreeFileSystemStrategy extends FileSystemStrategyBase {
               vscode.Uri.file(dirPath),
               true, // isDirectory = true
               undefined, // parent は undefined (ルートレベルまたはgetChildrenの直接の子)
-              bookmarkManager // BookmarkManagerを渡す
+              bookmarkManager, // BookmarkManagerを渡す
+              viewMode // ViewModeを渡す
             )
           );
         } catch (error) {
@@ -105,7 +112,8 @@ export class TreeFileSystemStrategy extends FileSystemStrategyBase {
               vscode.Uri.file(filePath),
               false, // isDirectory = false
               undefined, // parent は undefined (ルートレベルまたはgetChildrenの直接の子)
-              bookmarkManager // BookmarkManagerを渡す
+              bookmarkManager, // BookmarkManagerを渡す
+              viewMode // ViewModeを渡す
             )
           );
         } catch (error) {


### PR DESCRIPTION
<!-- PR作成時は以下のテンプレートに従って記入してください -->

## 変更内容
<!-- 変更の概要を簡潔に記述してください -->
FileItem の description プロパティを、File Explorer の ViewMode が flat の場合にのみ表示するように修正しました。
これにより、Tree View での表示がすっきりします。

## 関連するIssue
<!-- 関連するIssueがある場合は、「#123」のように記述してください -->
Closes # (関連Issueがあれば追記)

## 変更の種類
<!-- 該当する項目に x を入れてください（例: [x] ） -->
- [ ] バグ修正（既存機能の修正）
- [x] 新機能（既存機能に影響しない変更）
- [ ] 破壊的変更（既存機能に影響する変更）
- [ ] ドキュメントのみの変更
- [ ] リファクタリング（機能変更なし）
- [ ] パフォーマンス改善
- [ ] テストの追加・修正
- [ ] ビルドプロセスや補助ツールの変更
- [ ] その他（詳細を記述）

## チェックリスト
<!-- 該当する項目に x を入れてください（例: [x] ） -->
- [x] コードスタイルに準拠している
- [x] 自己レビューを行った
- [x] コメントを追加・更新した（特に複雑な部分）
- [ ] ドキュメントを更新した（必要な場合）
- [ ] テストを追加・更新した（必要な場合）
- [x] 変更がローカルでテスト済み

## スクリーンショット（必要な場合）
<!-- UI変更がある場合は、変更前後のスクリーンショットを添付してください -->
(UI変更なし)

## その他の情報
<!-- レビュアーに伝えたい追加情報があれば記述してください -->
型定義で `ViewMode` の代わりに `ViewModeType` を使用するように修正しました。
